### PR TITLE
20240719 improve delete api

### DIFF
--- a/cleezy
+++ b/cleezy
@@ -1,1 +1,0 @@
-/Users/jasonkim/Desktop/SCE/SCE-CLI/cleezy

--- a/cleezy
+++ b/cleezy
@@ -1,0 +1,1 @@
+/Users/jasonkim/Desktop/SCE/SCE-CLI/cleezy

--- a/server.py
+++ b/server.py
@@ -139,19 +139,14 @@ async def delete_url(alias: str):
             if sqlite_helpers.delete_url(DATABASE_FILE, alias):
                 try: # URL deleted, now attempt the associated data
                     qr_code_cache.delete(alias)
-                except Exception as e:
-                    logging.error(f"Error deleting QR code for {alias}: {str(e)}")
-
-                try:
                     cache.delete(alias)
-                except Exception as e:
-                    logging.error(f"Error deleting from cache for {alias}: {str(e)}") # log failure without raising exception
+                except Exception:
+                    logging.exception(f"Error deleting alias {alias} from cache") # log failure without raising exception
 
                 return {"message": "URL deleted successfully"}
-            else:
-                raise HTTPException(status_code=HttpResponse.NOT_FOUND.code)
-    except Exception as e:
-        logging.error(f"Unexpected error in delete_url for {alias}: {str(e)}")
+            raise HTTPException(status_code=HttpResponse.NOT_FOUND.code)
+    except Exception:
+        logging.error(f"Unexpected error in delete_url for {alias}")
         raise HTTPException(status_code=HttpResponse.INTERNAL_SERVER_ERROR.code)
 
 @app.get("/qr/{alias}") 


### PR DESCRIPTION
when the /delete endpoint was called, the url is deleted, but then trying to delete the associated data (qrcode) returns an error, which in turn confuses the frontend and disrupted the ui from being re-rendered. rewrote the api to handle errors such that it won't raise exceptions, but logs whatever failed. - might need to look into how to handle deletion of associated data later if it keeps occurring. 