### PR TITLE
add none check when deleting a QR code cache

### DIFF
--- a/modules/qr_code.py
+++ b/modules/qr_code.py
@@ -98,6 +98,9 @@ class QRCode:
 
     def delete(self, alias: str):
         path = self.mapping.get(alias)
+        if not path:
+            logging.debug(f"path not found in mapping for alias {alias}")
+            return None
         if alias in self.mapping:
             self.mapping.pop(alias)
         if os.path.exists(path):

--- a/modules/qr_code.py
+++ b/modules/qr_code.py
@@ -98,7 +98,7 @@ class QRCode:
 
     def delete(self, alias: str):
         path = self.mapping.get(alias)
-        if not path:
+        if path is None:
             logging.debug(f"path not found in mapping for alias {alias}")
             return None
         if alias in self.mapping:


### PR DESCRIPTION
Adds a null check to ensure that if an alias doesn’t have a corresponding path in self.mapping, the method logs a debug message and exits early, preventing a NoneType error.

This may also fix having to refresh the frontend page to see updated list of URLs after deleting.