### PR TITLE
add expiration timezone to args

### DIFF
--- a/modules/args.py
+++ b/modules/args.py
@@ -63,4 +63,9 @@ def get_args():
         "--qr-code-cache-state-file",
         help="the JSON file where the cache will map to. If not specified, the qr-code cache will be cleared",
     )
+    parser.add_argument(
+        "--expiration-date-timezone",
+        default="America/Los_Angeles",
+        help="the timezone that url expiration checks will use. defaults to America/Los_Angeles"
+    )
     return parser.parse_args()

--- a/modules/sqlite_helpers.py
+++ b/modules/sqlite_helpers.py
@@ -1,10 +1,14 @@
 import sqlite3
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 import logging
+from modules.args import get_args
 
 ROWS_PER_PAGE = 25
 
 logger = logging.getLogger(__name__)
+args = get_args()
+expiration_date_timezone = args.expiration_date_timezone
 
 def maybe_create_table(sqlite_file: str) -> bool:
     db = sqlite3.connect(sqlite_file)
@@ -35,7 +39,7 @@ def maybe_create_table(sqlite_file: str) -> bool:
         return False
 
 
-def insert_url(sqlite_file: str, url: str, alias: str, expiration_date: int):
+def insert_url(sqlite_file: str, url: str, alias: str, expiration_date: str):
     db = sqlite3.connect(sqlite_file)
     cursor = db.cursor()
     timestamp = datetime.now()
@@ -122,12 +126,16 @@ def maybe_delete_expired_url(sqlite_file, sqlite_row) -> bool: #returns True if 
     db = sqlite3.connect(sqlite_file)
     cursor = db.cursor()
 
+    tz = ZoneInfo(expiration_date_timezone)
+
     expiration_datetime = None
     # sqlite_row[5] represents the expiration datetime e.g., "2024-11-04 18:05:24.006593"
     if sqlite_row[5] is not None:
         expiration_datetime = datetime.strptime(sqlite_row[5], "%Y-%m-%d %H:%M:%S.%f")
+        expiration_datetime = expiration_datetime.replace(tzinfo=tz)
 
-    if expiration_datetime is not None and expiration_datetime < datetime.now():
+    now = datetime.now(tz)
+    if expiration_datetime is not None and expiration_datetime < now:
         sql = "DELETE FROM urls WHERE alias = ?"
         cursor.execute(sql, (sqlite_row[2], ))
         db.commit()


### PR DESCRIPTION
add the expiration timezone as an argparse argument.
it defaults to America/Los_Angeles

Timezone is loaded as a zoneinfo object, and then used when we need to determine if a url should be deleted